### PR TITLE
Fix nomethoderror when including helpers

### DIFF
--- a/lib/mountain_view/engine.rb
+++ b/lib/mountain_view/engine.rb
@@ -31,8 +31,8 @@ module MountainView
 
     initializer "mountain_view.add_helpers" do
       ActiveSupport.on_load :action_controller do
-        helper MountainView::ApplicationHelper
-        helper MountainView::ComponentHelper
+        ::ActionController::Base.helper MountainView::ApplicationHelper
+        ::ActionController::Base.helper MountainView::ComponentHelper
       end
     end
   end


### PR DESCRIPTION
Explicitly calls helper inclusion via ActionController::Base,
preventing errors in Rails 5.1 (Issue#52).